### PR TITLE
Set freed variables to nil where variable scope is not local

### DIFF
--- a/Units/Forms/UFRMOperation.pas
+++ b/Units/Forms/UFRMOperation.pas
@@ -300,7 +300,7 @@ end;
 procedure TFRMOperation.FormDestroy(Sender: TObject);
 begin
   if Assigned(FPAccount) then Dispose(FPAccount);
-  if assigned(FOperation) then FOperation.Free;
+  FreeAndNil(FOperation);
 end;
 
 function TFRMOperation.GetSenderAcccount: PAccount;

--- a/Units/Forms/UFRMWallet.pas
+++ b/Units/Forms/UFRMWallet.pas
@@ -728,15 +728,15 @@ begin
   Until i<0;
 
   step := 'Destroying NodeNotifyEvents';
-  FNodeNotifyEvents.Free;
+  FreeAndNil(FNodeNotifyEvents);
   //
   step := 'Assigning Nil to TNetData';
   TNetData.NetData.OnReceivedHelloMessage := Nil;
   TNetData.NetData.OnStatisticsChanged := Nil;
 
   step := 'Destroying grids operators';
-  FOperationsDBGrid.Free;
-  FBlockChainDBGrid.Free;
+  FreeAndNil(FOperationsDBGrid);
+  FreeAndNil(FBlockChainDBGrid);
 
   step := 'Ordered Accounts Key list';
   FreeAndNil(FOrderedAccountsKeyList);
@@ -753,7 +753,7 @@ begin
   TNode.Node.Free;
 
   step := 'Destroying Wallet';
-  FWalletKeys.Free;
+  FreeAndNil(FWalletKeys);
   step := 'Processing messages 2';
   Application.ProcessMessages;
   step := 'Destroying stringslist';

--- a/Units/PascalCoin/UAccounts.pas
+++ b/Units/PascalCoin/UAccounts.pas
@@ -720,8 +720,8 @@ begin
   for i := 0 to FListOfOrderedAccountKeysList.Count - 1 do begin
     TOrderedAccountKeysList( FListOfOrderedAccountKeysList[i] ).FAccountList := Nil;
   end;
-  FBlockAccountsList.Free;
-  FListOfOrderedAccountKeysList.Free;
+  FreeAndNil(FBlockAccountsList);
+  FreeAndNil(FListOfOrderedAccountKeysList);
   DeleteCriticalSection(Flock);
   inherited;
 end;
@@ -952,7 +952,7 @@ end;
 destructor TPCSafeBoxTransaction.Destroy;
 begin
   CleanTransaction;
-  FOrderedList.Free;
+  FreeAndNil(FOrderedList);
   inherited;
 end;
 
@@ -1105,7 +1105,7 @@ end;
 destructor TOrderedAccountList.Destroy;
 begin
   Clear;
-  FList.Free;
+  FreeAndNil(FList);
   inherited;
 end;
 
@@ -1244,7 +1244,7 @@ begin
     FAccountList.FListOfOrderedAccountKeysList.Remove(Self);
   end;
   Clear(true);
-  FOrderedAccountKeysList.Free;
+  FreeAndNil(FOrderedAccountKeysList);
   inherited;
 end;
 

--- a/Units/PascalCoin/UBlockChain.pas
+++ b/Units/PascalCoin/UBlockChain.pas
@@ -1057,9 +1057,9 @@ end;
 destructor TPCOperationsComp.Destroy;
 begin
   Clear(true);
-  FOperationsHashTree.Free;
-  FSafeBoxTransaction.Free;
-  FStreamPoW.Free;
+  FreeAndNil(FOperationsHashTree);
+  FreeAndNil(FSafeBoxTransaction);
+  FreeAndNil(FStreamPoW);
   inherited;
 end;
 
@@ -1254,8 +1254,7 @@ begin
   begin
     if AComponent = FBank then begin
       FBank := Nil;
-      FSafeBoxTransaction.Free;
-      FSafeBoxTransaction := Nil;
+      FreeAndNil(FSafeBoxTransaction);
     end;
   end;
 end;
@@ -1390,10 +1389,8 @@ end;
 procedure TPCOperationsComp.SetBank(const value: TPCBank);
 begin
   if FBank = value then exit;
-  if Assigned(FBank) then begin
-     FSafeBoxTransaction.Free;
-     FSafeBoxTransaction := Nil;
-  end;
+  if Assigned(FBank) then
+    FreeAndNil(FSafeBoxTransaction);
   FBank := value;
   if Assigned(value) then begin
     value.FreeNotification(Self);
@@ -1613,7 +1610,7 @@ end;
 destructor TOperationsHashTree.Destroy;
 begin
   ClearHastThree;
-  FHashTreeOperations.Free;
+  FreeAndNil(FHashTreeOperations);
   inherited;
 end;
 

--- a/Units/PascalCoin/UDBStorage.pas
+++ b/Units/PascalCoin/UDBStorage.pas
@@ -986,7 +986,7 @@ end;
 destructor TOperationsResumeList.Destroy;
 begin
   Clear;
-  FList.Free;
+  FreeAndNil(FList);
   inherited;
 end;
 

--- a/Units/PascalCoin/ULog.pas
+++ b/Units/PascalCoin/ULog.pas
@@ -92,18 +92,15 @@ begin
 end;
 
 destructor TLog.Destroy;
-var f : TFileStream;
-  l : TList;
+var l : TList;
   i : Integer;
   P : PLogData;
 begin
   FThreadSafeLogEvent.Terminate;
   FThreadSafeLogEvent.WaitFor;
-  FThreadSafeLogEvent.Free;
+  FreeAndNil(FThreadSafeLogEvent);
   _logs.Remove(Self);
-  f := FFileStream;
-  FFileStream := Nil;
-  f.Free;
+  FreeAndNil(FFileStream);
   l := FLogDataList.LockList;
   try
     for i := 0 to l.Count - 1 do begin
@@ -114,7 +111,7 @@ begin
   finally
     FLogDataList.UnlockList;
   end;
-  FLogDataList.Free;
+  FreeAndNil(FLogDataList);
   inherited;
 end;
 

--- a/Units/PascalCoin/UMiner.pas
+++ b/Units/PascalCoin/UMiner.pas
@@ -174,7 +174,7 @@ end;
 destructor TMinerThread.Destroy;
 begin
   DeleteCriticalSection(Flock);
-  FOperations.Free;
+  FreeAndNil(FOperations);
   inherited;
 end;
 

--- a/Units/PascalCoin/UNetProtocol.pas
+++ b/Units/PascalCoin/UNetProtocol.pas
@@ -536,17 +536,17 @@ begin
     while (l.Count>0) do DeleteNetClient(l,l.Count-1);
   finally
     FNodeServers.UnlockList;
-    FNodeServers.Free;
+    FreeAndNil(FNodeServers);
   end;
   l := FBlackList.LockList;
   try
     while (l.Count>0) do DeleteNetClient(l,l.Count-1);
   finally
     FBlackList.UnlockList;
-    FBlackList.Free;
+    FreeAndNil(FBlackList);
   end;
-  FNetConnections.Free;
-  FNodePrivateKey.Free;
+  FreeAndNil(FNetConnections);
+  FreeAndNil(FNodePrivateKey);
   FNetDataNotifyEventsThread.Terminate;
   FNetDataNotifyEventsThread.WaitFor;
   inherited;
@@ -1208,8 +1208,8 @@ end;
 
 destructor TNetServer.Destroy;
 begin
-  FTCPServer.Free;
-  FNetClients.Free;
+  FreeAndNil(FTCPServer);
+  FreeAndNil(FNetClients);
   inherited;
 end;
 
@@ -1380,8 +1380,9 @@ begin
     TNetData.NetData.NotifyNetConnectionUpdated;
   Finally
     DeleteCriticalSection(FNetLock);
-    if FClient.Owner=Self then FClient.Free;
-    FClientBufferRead.Free;
+    if FClient.Owner=Self then
+      FreeAndNil(FClient);
+    FreeAndNil(FClientBufferRead);
     inherited;
   End;
 end;
@@ -2480,7 +2481,7 @@ begin
       FNetClientThread.WaitFor;
     end;
     debugStep := 'Freeing';
-    FNetClientThread.Free;
+    FreeAndNil(FNetClientThread);
     debugStep := 'Inherited';
     inherited;
   Except
@@ -2691,7 +2692,7 @@ begin
   DebugStep := 'Destroying NetClient if exists';
   if TNetData.NetData.ConnectionExists(FNetClient) then begin
     DebugStep := 'Destroying NetClient...';
-    FNetClient.Free;
+    FreeAndNil(FNetClient);
   end else TLog.NewLog(ltdebug,classname,'Connection not exists!');
 end;
 

--- a/Units/PascalCoin/UNode.pas
+++ b/Units/PascalCoin/UNode.pas
@@ -441,19 +441,19 @@ begin
     while (MinersCount>0) do DeleteMiner(0);
 
     step := 'Destroying NetServer';
-    FNetServer.Free;
+    FreeAndNil(FNetServer);
     step := 'Destroying MinerThreads';
-    FMinerThreads.Free;
+    FreeAndNil(FMinerThreads);
 
     step := 'Destroying NotifyList';
-    FNotifyList.Free;
+    FreeAndNil(FNotifyList);
     step := 'Destroying Operations';
-    FOperations.Free;
+    FreeAndNil(FOperations);
     step := 'Assigning NIL to node var';
     if _Node=Self then _Node := Nil;
 
     step := 'Destroying Bank';
-    FBank.Free;
+    FreeAndNil(FBank);
 
     step := 'inherited';
     inherited;
@@ -647,8 +647,8 @@ begin
   if Assigned(FNode) then FNode.FNotifyList.Remove(Self);
   FThreadSafeNodeNotifyEvent.FNodeNotifyEvents := Nil;
   FThreadSafeNodeNotifyEvent.Terminate;
-  FPendingNotificationsList.Free;
-  FMessages.Free;
+  FreeAndNil(FPendingNotificationsList);
+  FreeAndNil(FMessages);
   inherited;
 end;
 
@@ -766,12 +766,12 @@ end;
 
 destructor TThreadNodeNotifyOperations.Destroy;
 begin
-  FOperationsHashTree.Free;
+  FreeAndNil(FOperationsHashTree);
   inherited;
 end;
 
 initialization
   _Node := Nil;
 finalization
-  _Node.Free;
+  FreeAndNil(_Node);
 end.

--- a/Units/PascalCoin/UThread.pas
+++ b/Units/PascalCoin/UThread.pas
@@ -59,7 +59,7 @@ uses
 
 { TPCThread }
 
-Var _threads,_aux : TPCThreadList;
+Var _threads : TPCThreadList;
 
 procedure TPCThread.DoTerminate;
 begin
@@ -199,7 +199,7 @@ destructor TPCThreadList.Destroy;
 begin
   LockList;
   try
-    FList.Free;
+    FreeAndNil(FList);
     inherited Destroy;
   finally
     UnlockList;
@@ -231,7 +231,5 @@ end;
 initialization
   _threads := TPCThreadList.Create;
 finalization
-  _aux := _threads;
-  _threads := Nil;
-  _aux.Free;
+  FreeAndNil(_threads);
 end.


### PR DESCRIPTION
If a variable is accessible from another scope, it should be set to nil when it is freed. This will help in tracking down access violations.
