### PR TITLE
refactored fix for #76

### DIFF
--- a/Units/PascalCoin/UBlockChain.pas
+++ b/Units/PascalCoin/UBlockChain.pas
@@ -301,6 +301,7 @@ Type
     Class Function GetOperationClassByOpType(OpType: Cardinal): TPCOperationClass;
     Class Function GetFirstBlock : TOperationBlock;
     Class Function EqualsOperationBlock(Const OperationBlock1,OperationBlock2 : TOperationBlock):Boolean;
+    Procedure EstimatePoW(Const withBlockPayload: TRawBytes; Const withTimestamp, withNOnce: Cardinal; var PoW:TRawBytes);
     //
     Property SafeBoxTransaction : TPCSafeBoxTransaction read FSafeBoxTransaction;
     Property OperationsHashTree : TOperationsHashTree read FOperationsHashTree;
@@ -841,6 +842,17 @@ begin
   FStreamPoW.Write(FOperationBlock.timestamp,4);
   FStreamPoW.Write(FOperationBlock.nonce,4);
   TCrypto.DoDoubleSha256(FStreamPoW.Memory,length(FDigest_Part1)+length(FDigest_Part2_Payload)+length(FDigest_Part3)+8,PoW);
+end;
+
+Procedure TPCOperationsComp.EstimatePoW(Const withBlockPayload: TRawBytes; Const withTimestamp, withNOnce: Cardinal; var PoW:TRawBytes);
+begin
+ FStreamPoW.Position := 0;
+  FStreamPoW.WriteBuffer(FDigest_Part1[1],length(FDigest_Part1));
+  FStreamPoW.WriteBuffer(withBlockPayload[1],length(withBlockPayload));
+  FStreamPoW.WriteBuffer(FDigest_Part3[1],length(FDigest_Part3));
+  FStreamPoW.Write(withTimestamp,4);
+  FStreamPoW.Write(withNOnce,4);
+  TCrypto.DoDoubleSha256(FStreamPoW.Memory,length(FDigest_Part1)+length(withBlockPayload)+length(FDigest_Part3)+8,PoW);
 end;
 
 procedure TPCOperationsComp.Calc_Digest_Parts;

--- a/Units/PascalCoin/UPoolMining.pas
+++ b/Units/PascalCoin/UPoolMining.pas
@@ -817,13 +817,13 @@ begin
       i := l.Count-1;
       while (i>=0) And (Not Assigned(nbOperations)) do begin
         P := l[i];
-        P^.OperationsComp.BlockPayload := _payload;
         // Best practices: Only will accept a solution if timestamp >= sent timestamp for this job (1.5.3)
         If (P^.SentMinTimestamp<=_timestamp) then begin
-          P^.OperationsComp.timestamp := _timestamp;
-          P^.OperationsComp.nonce := _nOnce;
           _targetPoW := FNodeNotifyEvents.Node.Bank.SafeBox.GetActualTargetHash(P^.OperationsComp.OperationBlock.protocol_version=CT_PROTOCOL_2);
           if (P^.OperationsComp.OperationBlock.proof_of_work<=_targetPoW) then begin
+            P^.OperationsComp.BlockPayload := _payload;
+            P^.OperationsComp.timestamp := _timestamp;
+            P^.OperationsComp.nonce := _nOnce;
             // Candidate!
             nbOperations := TPCOperationsComp.Create(Nil);
             nbOperations.bank := FNodeNotifyEvents.Node.Bank;

--- a/Units/PascalCoin/UPoolMining.pas
+++ b/Units/PascalCoin/UPoolMining.pas
@@ -785,7 +785,7 @@ Var s : String;
   l : TList;
   _payloadHexa,_payload : AnsiString;
   _timestamp, _nOnce : Cardinal;
-  _targetPoW : TRawBytes;
+  _targetPoW,_solutionPoW : TRawBytes;
 begin
   { Miner params must submit:
     - "payload" as an Hexadecimal
@@ -820,7 +820,8 @@ begin
         // Best practices: Only will accept a solution if timestamp >= sent timestamp for this job (1.5.3)
         If (P^.SentMinTimestamp<=_timestamp) then begin
           _targetPoW := FNodeNotifyEvents.Node.Bank.SafeBox.GetActualTargetHash(P^.OperationsComp.OperationBlock.protocol_version=CT_PROTOCOL_2);
-          if (P^.OperationsComp.OperationBlock.proof_of_work<=_targetPoW) then begin
+          P^.OperationsComp.EstimatePoW(_payload, _timestamp, _nOnce, _solutionPoW);
+          if (_solutionPoW<=_targetPoW) then begin
             P^.OperationsComp.BlockPayload := _payload;
             P^.OperationsComp.timestamp := _timestamp;
             P^.OperationsComp.nonce := _nOnce;


### PR DESCRIPTION
Delegates solution candidate PoW calculation to the `TPCOperationsComp`. It has part1/part3 precalculated. 
I doubt if we could use TPCOperationsComp.Bank to evaluate `SafeBox.GetActualTargetHash` in there. If it possible then `_targetPoW` and PoW comparison could be isolated too
PS:  done some code cleanup of `UPoolMining.pas`