### PR TITLE
add compiled binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.exe
 *.identcache
 *.stat
+src/PascalCoinWallet
+src/PascalCoinMiner
+src/pascalcoin_daemon
 
 ## OpenSSL 
 libeay32.dll


### PR DESCRIPTION
compiling sources with default config will put them to the `src/` 
it is really annoying to exclude executables compiled from changes to be commited