### PR TITLE
Added new parameters to findaccounts

### DIFF
--- a/src/core/URPC.pas
+++ b/src/core/URPC.pas
@@ -2230,7 +2230,7 @@ function TRPCProcess.ProcessMethod(const method: String; params: TPCJSONObject;
       // Search by type-forSale-balance
       for i := start to FNode.Bank.AccountsCount - 1 do begin
         account := FNode.Operations.SafeBoxTransaction.Account(i);
-        if (accountType <> -1) AND (Integer(account.account_type) = accountType) then
+        if (accountType <> -1) AND (Integer(account.account_type) <> accountType) then
         begin
            Continue;
         end;


### PR DESCRIPTION
Added following parameters:

- new boolean parameter 'listed' (by default false): If true, filters returning only accounts for sale

- new boolean parameter 'exact' (by default true): If false, includes all accounts whose name starts by the value of 'name' parameter. If true returns exact match (as in the actual version) 

- new double parameter 'min_balance' (by default -1). If >0, filters accounts with balance greater or equal that its value 

- new double parameter 'max_balance' (by default -1). If >0, filters accounts with balance less or equal than its value