### PR TITLE
Fix RPC "executeoperations" error message

### DIFF
--- a/src/core/URPC.pas
+++ b/src/core/URPC.pas
@@ -1367,6 +1367,7 @@ function TRPCProcess.ProcessMethod(const method: String; params: TPCJSONObject;
     i : Integer;
     OperationsResumeList : TOperationsResumeList;
   Begin
+    Result := false;
     if Not HexaStringToOperationsHashTree(HexaStringOperationsHashTree,OperationsHashTree,errors) then begin
       ErrorNum:=CT_RPC_ErrNum_InvalidData;
       ErrorDesc:= 'Error decoding param "rawoperations": '+errors;


### PR DESCRIPTION
Without this I was simply getting `{"id":0,"jsonrpc":"2.0"}` back with invalid inputs.