### PR TITLE
Pasc donations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ View the changelog [here](CHANGELOG.md)
 ## Donations  
   
 Consider a donation using Pascal coin to development account: `0-10`
+
 Also, consider a donation using BitCoin to `16K3HCZRhFUtM8GdWRcfKeaa6KsuyxZaYk`

--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ View the changelog [here](CHANGELOG.md)
 
 ## Donations  
   
-Consider a donation using BitCoin to `16K3HCZRhFUtM8GdWRcfKeaa6KsuyxZaYk`
+Consider a donation using Pascal coin to development account: `0-10`
+Also, consider a donation using BitCoin to `16K3HCZRhFUtM8GdWRcfKeaa6KsuyxZaYk`


### PR DESCRIPTION
Moved PASC donation address back. Who needs BTC if we have PASC? It's easier to donate in PASC, no need to download all the blockchain and transactions are free. Block time is less too, by the way.