### PR TITLE
Delphi 10.4 restricted FreeAndNil to objects so cannot be used on Rec…

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -35,7 +35,9 @@
 
   // Activate to define CryptoLib4Pascal by default on all compilations
   {.$DEFINE Use_CryptoLib4Pascal}
-
+  // Add the following paths to the project Search Path is this option is used
+  // .\libraries\cryptolib4pascal
+  // .\libraries\simplebaselib4pascal  
 
   // Used to activate RandomHash in V4 hard-fork
   {$DEFINE ACTIVATE_RANDOMHASH_V4}

--- a/src/config.inc
+++ b/src/config.inc
@@ -111,6 +111,10 @@ ERROR: You must select ONLY ONE option: Use_OpenSSL or Use_CryptoLib4Pascal
   {$ELSE}
     {$UNDEF NO_ANSISTRING}
   {$ENDIF}
+  
+  {$IF COMPILERVERSION > 33}
+    {$DEFINE DELPHI_SYDNEY_PLUS}  
+  {$ENDIF}
 {$ENDIF}
 
 

--- a/src/core/UNetProtocol.pas
+++ b/src/core/UNetProtocol.pas
@@ -1243,7 +1243,12 @@ Var l : TList<TNetConnection>;
   tdc : TThreadDiscoverConnection;
 begin
   TLog.NewLog(ltInfo,ClassName,'TNetData.Destroy START');
+  {$IFDEF DELPHI_SYDNEY_PLUS }
+  SetLength(FOnConnectivityChanged.Handlers, 0);
+  SetLength(FOnConnectivityChanged.MainThreadHandlers, 0);
+  {$ELSE}
   FreeAndNil(FOnConnectivityChanged);
+  {$ENDIF}
   FOnGetNewBlockchainFromClientDownloadNewSafebox := Nil;
   FOnStatisticsChanged := Nil;
   FOnNetConnectionsUpdated := Nil;


### PR DESCRIPTION
Delphi 10.4 only allows objects to be passed to FreeAndNil.

conditional define added to src/config.ic to identify Delphi Version 10.4 and greater.
conditional FreeAndNil in /src/core/UNETProtocol TNetData.Destroy to manage this change