### PR TITLE
Updated .gitignore to ignore *.rsm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ dunit.ini
 /src/*.tvsconfig
 src/libssl-1_1.dll
 src/libssl-1_1-x64.dll
+*.rsm


### PR DESCRIPTION
Please add this to .gitignore.

*.rsm are very large debug files for remote debugging and should not be tracked by git.