### PR TITLE
Packed directive added to record TBlockHeader.

### DIFF
--- a/src/core/UFileStorage.pas
+++ b/src/core/UFileStorage.pas
@@ -29,7 +29,7 @@ uses
 
 
 Type
-  TBlockHeader = Record
+  TBlockHeader = packed record
     BlockNumber : Cardinal;
     StreamBlockRelStartPos : Int64;
     BlockSize : Cardinal;


### PR DESCRIPTION
Record TBlockHeader is of size 24 bytes on win64 platform. This is due to quad word alignment in compiler settings.

To force the record into 16 bytes, the packed directive should be used.

Untested what the side effects could be of this, possibilities:

1. Slight slow down of existing code.
2. Perhaps some memory savings here and there.

The current PascalCoin is not affected because it loads fields individually. This could be sped up somewhat by loading the blockheader all at once.